### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module alfred-gcloud-shortcuts
+module github.com/jarlefosen/alfred-gcloud-shortcuts
 
 go 1.12
 


### PR DESCRIPTION
The packages are not go installable now, I think this will resolve it.

```
$ go install github.com/jarlefosen/alfred-gcloud-shortcuts/cmd/products@latest
go install: github.com/jarlefosen/alfred-gcloud-shortcuts/cmd/products@latest: module github.com/jarlefosen/alfred-gcloud-shortcuts@latest found (v1.0.1), but does not contain package github.com/jarlefosen/alfred-gcloud-shortcuts/cmd/products
```