### PR TITLE
arm build for m3 mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ workflow: build clean target/
 	bin/projects
 
 build-projects:
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags='-s -w' -trimpath -o bin/projects cmd/projects/*.go
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags='-s -w' -trimpath -o bin/projects cmd/projects/*.go
 
 build-products:
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags='-s -w' -trimpath -o bin/products cmd/products/*.go
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags='-s -w' -trimpath -o bin/products cmd/products/*.go
 
 build: build-projects build-products
 

--- a/info.plist
+++ b/info.plist
@@ -364,7 +364,7 @@ Run `g-refresh` which will update the cache of projects</string>
 		<string>authuser</string>
 	</array>
 	<key>version</key>
-	<string>2.0.9</string>
+	<string>2.0.17-arm</string>
 	<key>webaddress</key>
 	<string>https://github.com/jarlefosen/alfred-gcloud-shortcuts</string>
 </dict>


### PR DESCRIPTION
Bad CPU type in executable

I updated the amd to arm and it worked. This is a workaround for some users and hopefully will start the discussion. 

This doesn't work with the older mac amd chips. I'm not sure if there's a way to support both. Hopefully you might.